### PR TITLE
fix: avoid running a watcher on external directory

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -18,7 +18,6 @@ config :phoenix_storybook_demo, PhoenixStorybookDemo.Endpoint,
     # Start the esbuild watcher by calling Esbuild.install_and_run(:default, args)
     esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]},
-    npm: ["run", "watch", cd: Path.expand("../../phoenix_storybook/assets", __DIR__)]
   ],
   reloadable_apps: [:phoenix_storybook_demo, :phoenix_storybook]
 


### PR DESCRIPTION
### Context

I was tinkering with this demo app while trying to debug a related issue, and I keep seeing the following while running the server:

```
spawn: Could not cd to /Users/scott/home/phoenix_storybook/assets
[error] Task #PID<0.4240.0> started from PhoenixStorybookDemo.Endpoint terminating
** (stop) :watcher_command_error
    (phoenix 1.7.11) lib/phoenix/endpoint/watcher.ex:55: Phoenix.Endpoint.Watcher.watch/2
    (elixir 1.15.5) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: &Phoenix.Endpoint.Watcher.watch/2
    Args: ["npm", ["run", "watch", {:cd, "/Users/scott/home/phoenix_storybook/assets"}]]
spawn: Could not cd to /Users/scott/home/phoenix_storybook/assets
```

I don't think the actual demo is being built with assets located outside this projects structure, so it should be safe to remove this watcher for cleaner logs.